### PR TITLE
fix some grammatical errors

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,7 @@ import ThemeToggle from "./ThemeToggle.svelte";
                 <span class="divider">&mdash;</span>
                 <span>
                     Discord is a trademark of Discord Inc. Vencord is not
-                    affiliated or endorsed by Discord Inc.
+                    affiliated with or endorsed by Discord Inc.
                 </span>
             </span>
         </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,7 +10,7 @@ import ThemeToggle from "./ThemeToggle.svelte";
                 <a href={SOURCE_CODE}>source code</a>
                 <span class="divider">&mdash;</span>
                 <span>
-                    Discord is trademark of Discord Inc. Vencord is not
+                    Discord is a trademark of Discord Inc. Vencord is not
                     affiliated or endorsed by Discord Inc.
                 </span>
             </span>


### PR DESCRIPTION
Simple grammatical correction, but pretty obvious, especially because it's in caps and in the footer of the website.

**original text:**
> *Discord is trademark of Discord Inc. Vencord is not affiliated or endorsed by Discord Inc.*

**corrected text:**
> *Discord is a trademark of Discord Inc. Vencord is not affiliated with or endorsed by Discord Inc.*