### PR TITLE
SEO: add structured data

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,6 +12,14 @@ export interface Props {
 }
 
 const { title, description, opengraph } = Astro.props;
+
+const structuredData = JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Vencord",
+    alternateName: "VC",
+    url: Astro.site,
+});
 ---
 
 <!DOCTYPE html>
@@ -56,6 +64,8 @@ const { title, description, opengraph } = Astro.props;
                 <meta name="og:site_name" content="Vencord" />
             )
         }
+
+        <script type="application/ld+json" set:html={structuredData}></script>
 
         <link rel="sitemap" href="/sitemap-index.xml" />
         {/* explode darkreader */}

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -5,6 +5,22 @@ import Layout from "layouts/Layout.astro";
 import { getSortedFaq } from "scripts/collections";
 
 const faq = await getSortedFaq();
+
+// this sucks, but it's the only way to generate the right data for structured data
+// regardless, this only runs at prerender time so it's okay
+const rawFaqData = await Astro.glob("../content/faq/*.md");
+const structuredData = JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: rawFaqData.map(f => ({
+        "@type": "Question",
+        name: f.frontmatter.title,
+        acceptedAnswer: {
+            "@type": "Answer",
+            text: f.compiledContent(),
+        },
+    })),
+});
 ---
 
 <Layout
@@ -35,6 +51,8 @@ const faq = await getSortedFaq();
         Still lost? Visit our <a href="/discord">support server</a> for more assistance!
         We're happy to help.
     </p>
+
+    <script type="application/ld+json" set:html={structuredData}></script>
 </Layout>
 
 <style>


### PR DESCRIPTION
This helps improve SEO by adding some structured data tags to the page. This adds a `WebSite` schema (which makes it easier for Google to know the site name and canonical in the event that it gets confused) and, specifically for the FAQ page, the `FAQPage` structured data which *can* be rendered as those FAQ dropdowns in Google search. Even if they don't get rendered, it contributes to SEO greatly (according to, well, Google).